### PR TITLE
Rework SearchPage so back button works correctly

### DIFF
--- a/src/frontend/src/components/SearchBar/SearchBar.jsx
+++ b/src/frontend/src/components/SearchBar/SearchBar.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { navigate } from 'gatsby';
 import PropTypes from 'prop-types';
 import SearchIcon from '@material-ui/icons/Search';
 
@@ -88,29 +87,7 @@ const useStyles = makeStyles((theme) => ({
 
 function CustomizedInputBase(props) {
   const classes = useStyles();
-  const { searchText, onChangeHandler, onFilterChangeHandler, filter, onFormSubmit } = props;
-
-  const prepareParamsAndNavigate = (text, filter) => {
-    navigate(`/search?text=${encodeURIComponent(text)}&filter=${encodeURIComponent(filter)}`, {
-      replace: true,
-    });
-  };
-
-  const onFilterChange = (event) => {
-    onFilterChangeHandler(event.target.value);
-    prepareParamsAndNavigate(searchText, event.target.value);
-  };
-
-  const onTextChange = (event) => {
-    onChangeHandler(event.target.value);
-    prepareParamsAndNavigate(event.target.value, filter);
-  };
-
-  const onSubmit = (event) => {
-    event.preventDefault();
-    onFormSubmit();
-    prepareParamsAndNavigate(searchText, filter);
-  };
+  const { text, onTextChange, onFilterChange, filter, onSubmit } = props;
 
   const searchOptions = ['post', 'author'];
 
@@ -133,7 +110,7 @@ function CustomizedInputBase(props) {
         </Grid>
         <Fab size="large" className={classes.iconButton}>
           <FormControl>
-            <IconButton type="submit" onClick={(event) => onSubmit(event)} aria-label="search">
+            <IconButton type="submit" onClick={onSubmit} aria-label="search">
               <SearchIcon />
             </IconButton>
           </FormControl>
@@ -148,7 +125,7 @@ function CustomizedInputBase(props) {
                 value={filter}
                 variant="outlined"
                 className={classes.selectControl}
-                onChange={(event) => onFilterChange(event)}
+                onChange={(event) => onFilterChange(event.target.value)}
               >
                 {searchOptions.map((option) => (
                   <MenuItem key={option} value={option} className={classes.selectItem}>
@@ -165,8 +142,8 @@ function CustomizedInputBase(props) {
                 placeholder="How to Get Started in Open Source"
                 inputProps={{ 'aria-label': 'search telescope' }}
                 variant="outlined"
-                value={searchText}
-                onChange={(event) => onTextChange(event)}
+                value={text}
+                onChange={(event) => onTextChange(event.target.value)}
               />
             </FormControl>
           </Grid>
@@ -177,10 +154,10 @@ function CustomizedInputBase(props) {
 }
 
 CustomizedInputBase.propTypes = {
-  searchText: PropTypes.string,
-  onChangeHandler: PropTypes.func,
-  onFilterChangeHandler: PropTypes.func,
-  onFormSubmit: PropTypes.func,
+  text: PropTypes.string,
+  onTextChange: PropTypes.func,
   filter: PropTypes.string,
+  onFilterChange: PropTypes.func,
+  onSubmit: PropTypes.func,
 };
 export default CustomizedInputBase;

--- a/src/frontend/src/components/SearchPage/SearchPage.jsx
+++ b/src/frontend/src/components/SearchPage/SearchPage.jsx
@@ -1,97 +1,40 @@
-import React, { useState, useEffect } from 'react';
-
-import { Container } from '@material-ui/core';
-import Box from '@material-ui/core/Box';
+import React, { useState } from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';
-import { makeStyles } from '@material-ui/core/styles';
 
-import useSiteMetadata from '../../hooks/use-site-metadata';
-
-import Timeline from '../Posts/Timeline.jsx';
 import SearchBar from '../SearchBar';
-import Spinner from '../Spinner';
-//import { useEffect } from 'react';
-
-const useStyles = makeStyles(() => ({
-  spinner: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  searchResults: {
-    padding: 0,
-    width: '785px',
-    justifyContent: 'center',
-  },
-}));
+import SearchResults from './SearchResults.jsx';
 
 const SearchPage = () => {
-  const { telescopeUrl } = useSiteMetadata();
-  const classes = useStyles();
-  const [searchText = '', setSearchText] = useQueryParam('text', StringParam);
-  const [filter = 'post', setFilter] = useQueryParam('filter', StringParam);
-  const [results, setResults] = useState(undefined);
-  const [fetchLoading, setFetchLoading] = useState(false);
+  // We synchronize the `text` and `filter` values to the URL's query string
+  // via `textParam` and `filterParam`. The <SearchBar> UI uses our internal
+  // state values, and the <SearchResults> only update on page load or when
+  // the user submits the form.
+  const [textParam = '', setTextParam] = useQueryParam('text', StringParam);
+  const [filterParam = 'post', setFilterParam] = useQueryParam('filter', StringParam);
 
-  const search = async () => {
-    const encodedSearchText = encodeURIComponent(searchText);
-    try {
-      setFetchLoading(true);
-      const res = await fetch(`${telescopeUrl}/query?text=${encodedSearchText}&filter=${filter}`);
-      if (!res.ok) {
-        throw new Error(res.statusText);
-      }
-      const posts = await res.json();
-      setResults(posts.values);
-    } catch (error) {
-      console.error('Something went wrong while fetching data', error);
-    } finally {
-      setFetchLoading(false);
-    }
-  };
+  // We manage the state of `text` and `filter` internally, and update URL on
+  // form submit only.  These are used in the <SearchBar>, and the user can change them.
+  const [text, setText] = useState(textParam);
+  const [filter, setFilter] = useState(filterParam);
 
-  useEffect(() => {
-    search();
-  }, [telescopeUrl]);
-
-  // Displays one of three options depending on whether there is a search string, results and no results
-  const displayResults = () => {
-    if (searchText.length > 0 && fetchLoading) {
-      return (
-        <h1 className={classes.spinner}>
-          <Spinner />
-        </h1>
-      );
-    }
-
-    if (!results) {
-      return null;
-    }
-    return <Timeline pages={[results]} />;
-  };
-
-  function onChangeHandler(value) {
-    setSearchText(value);
-  }
-
-  function onFilterChangeHandler(value) {
-    setFilter(value);
-  }
-
-  function onFormSubmitHandler() {
-    search();
+  // Form was submitted, so go ahead and sync to URL, (re)triggering search.
+  function onSubmitHandler(event) {
+    event.preventDefault();
+    setTextParam(text);
+    setFilterParam(filter);
   }
 
   return (
     <div>
       <SearchBar
-        searchText={searchText}
-        onChangeHandler={onChangeHandler}
+        text={text}
+        onTextChange={(value) => setText(value)}
         filter={filter}
-        onFormSubmit={onFormSubmitHandler}
-        onFilterChangeHandler={onFilterChangeHandler}
+        onFilterChange={(value) => setFilter(value)}
+        onSubmit={onSubmitHandler}
       />
       <br />
-      <Container className={classes.searchResults}>{displayResults()}</Container>
+      <SearchResults text={textParam} filter={filterParam} />
     </div>
   );
 };

--- a/src/frontend/src/components/SearchPage/SearchResults.jsx
+++ b/src/frontend/src/components/SearchPage/SearchResults.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import useSWR from 'swr';
+import { Container } from '@material-ui/core';
+
+import useSiteMetadata from '../../hooks/use-site-metadata';
+import Timeline from '../Posts/Timeline.jsx';
+import Spinner from '../Spinner';
+
+const useStyles = makeStyles(() => ({
+  spinner: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  searchResults: {
+    padding: 0,
+    width: '785px',
+    justifyContent: 'center',
+  },
+}));
+
+const SearchResults = ({ text, filter }) => {
+  const classes = useStyles();
+  const { telescopeUrl } = useSiteMetadata();
+  const url = `${telescopeUrl}/query?text=${encodeURIComponent(text)}&filter=${filter}`;
+
+  // We only bother doing the request if we have something to search for.
+  const shouldFetch = () => text.length > 0;
+  const { data, loading, error } = useSWR(shouldFetch() ? url : null, async (u) => {
+    const res = await fetch(u);
+    const results = await res.json();
+    return results.values;
+  });
+
+  if (error) {
+    // TODO: https://github.com/Seneca-CDOT/telescope/issues/1279
+    return (
+      <Container className={classes.searchResults}>
+        <p>Error loading search results</p>;
+      </Container>
+    );
+  }
+
+  if (text.length && loading) {
+    return (
+      <Container className={classes.searchResults}>
+        <h1 className={classes.spinner}>
+          <Spinner />
+        </h1>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className={classes.searchResults}>
+      {data && data.length ? <Timeline pages={[data]} /> : <h1>No results search</h1>}
+    </Container>
+  );
+};
+
+SearchResults.propTypes = {
+  text: PropTypes.string,
+  filter: PropTypes.string,
+};
+
+export default SearchResults;


### PR DESCRIPTION
I played with your branch and decided to make some fixes vs. trying to explain it all over Slack.

This fixes the query param state logic, and also gets the Back button to work the way we want.  I do it by using both `useQueryParam()` but also `useState()`.  I seed the state for `text` and `filter` from the query string, but then manage it separate, so the user can update them in the form.  When they click submit, it causes the values to get set in the query string, which in turn causes a new search to get triggered.

I've pulled the search results logic into its own component, and pass it the values form the query params in the URL.  Thus, they only update when the URL updates (onload or when the form is submitted).

I removed the `navigate()` calls, since we don't need them anymore.

I also renamed some variables and functions.

Test it and see if you're happy.  If so, please merge it, and then we can get a review on your PR and merge the whole thing.